### PR TITLE
Install docker-compose's missing dependencies

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,20 +36,20 @@
     state: started
     enabled: true
 
-- name: Uninstall Pip's backport as it has conflict with compose
+- name: Uninstall Pip's backport as it has conflict with compose.
   pip:
     name: backports.ssl-match-hostname
     state: absent
   when: docker_install_compose | bool
 
-- name: Install backports as a Raspbian package
+- name: Install backports as a Raspbian package.
   apt:
     name: python-backports.ssl-match-hostname
     state: present
     force: true
   when: docker_install_compose | bool
 
-- name: Install Compose's missing dependency
+- name: Install Compose's missing dependency.
   apt:
     name: libffi-dev
     state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,7 @@
   pip:
     name: backports.ssl-match-hostname
     state: absent
+  failed_when: false
   when: docker_install_compose | bool
 
 - name: Install backports as a Raspbian package.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,6 +36,26 @@
     state: started
     enabled: true
 
+- name: Uninstall Pip's backport as it has conflict with compose
+  pip:
+    name: backports.ssl-match-hostname
+    state: absent
+  when: docker_install_compose | bool
+
+- name: Install backports as a Raspbian package
+  apt:
+    name: python-backports.ssl-match-hostname
+    state: present
+    force: true
+  when: docker_install_compose | bool
+
+- name: Install Compose's missing dependency
+  apt:
+    name: libffi-dev
+    state: present
+    force: true
+  when: docker_install_compose | bool
+
 - name: Install Docker Compose using Pip.
   pip:
     name: docker-compose


### PR DESCRIPTION
This PR solves some errors I had on a clean installation of Raspbian (Buster).

- Install `libffi-dev` to avoid the following error at docker-compose installation:

        ...
        arm-linux-gnueabihf-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -Wdate-time -D_FORTIFY_SOURCE=2 -g -fdebug-prefix-map=/build/python2.7-9NJ3qw/python2.7-2.7.16=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/usr/include/python2.7 -c c/_cffi_backend.c -o build/temp.linux-armv7l-2.7/c/_cffi_backend.o
              c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
               #include <ffi.h>
                        ^~~~~~~
              compilation terminated.
              error: command 'arm-linux-gnueabihf-gcc' failed with exit status 1
        ...

- Use the distribution's package `backports.ssl-match-hostname` instead of the one from `pip` to avoid this error:

        $ docker-compose --version
        Traceback (most recent call last):
          File "/usr/local/bin/docker-compose", line 6, in <module>
            from compose.cli.main import main
          File "/usr/local/lib/python2.7/dist-packages/compose/cli/main.py", line 17, in <module>
            import docker
          File "/usr/local/lib/python2.7/dist-packages/docker/__init__.py", line 2, in <module>
            from .api import APIClient
          File "/usr/local/lib/python2.7/dist-packages/docker/api/__init__.py", line 2, in <module>
            from .client import APIClient
          File "/usr/local/lib/python2.7/dist-packages/docker/api/client.py", line 10, in <module>
            from .build import BuildApiMixin
          File "/usr/local/lib/python2.7/dist-packages/docker/api/build.py", line 6, in <module>
            from .. import auth
          File "/usr/local/lib/python2.7/dist-packages/docker/auth.py", line 9, in <module>
            from .utils import config
          File "/usr/local/lib/python2.7/dist-packages/docker/utils/__init__.py", line 3, in <module>
            from .decorators import check_resource, minimum_version, update_headers
          File "/usr/local/lib/python2.7/dist-packages/docker/utils/decorators.py", line 4, in <module>
            from . import utils
          File "/usr/local/lib/python2.7/dist-packages/docker/utils/utils.py", line 13, in <module>
            from .. import tls
          File "/usr/local/lib/python2.7/dist-packages/docker/tls.py", line 5, in <module>
            from .transport import SSLHTTPAdapter
          File "/usr/local/lib/python2.7/dist-packages/docker/transport/__init__.py", line 3, in <module>
            from .ssladapter import SSLHTTPAdapter
          File "/usr/local/lib/python2.7/dist-packages/docker/transport/ssladapter.py", line 23, in <module>
            from backports.ssl_match_hostname import match_hostname
        ImportError: No module named ssl_match_hostname
