### PR TITLE
add install_recommends: no, fixes #11

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
     name: "docker-ce={{ docker_version }}"
     state: present
     force: true
+    install_recommends: no
 
 # Shim for Docker 18.09.0 on Debian Stretch.
 - import_tasks: docker-1809-shim.yml


### PR DESCRIPTION
Added `install_recommends: no` based on information from https://github.com/raspberrypi/linux/issues/3021.