### PR TITLE
Make role work on Pi1/Zero boards

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ docker_version_armv7: 5:19.03.12~3-0~raspbian-buster
 docker_version_arm64: 5:19.03.9~3-0~debian-buster
 
 # Check available versions on a Pi: `apt-cache madison docker-ce`
-docker_version: "{{ docker_version_armv7 if 'armv7' in ansible_architecture else docker_version_arm64 }}"
+docker_version: "{{ docker_version_armv7 if ('armv7' in ansible_architecture or 'armv6' in ansible_architecture) else docker_version_arm64 }}"
 
 # Whether to install recommended packages alongside docker-ce.
 docker_install_recommends: false


### PR DESCRIPTION
These are `armv6l` hardware and will want the `raspbian` version of the package (though the Debian arch code is `armhf` rather than `armv6`).