### PR TITLE
support armv6

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,10 @@
 ---
+docker_version_armv6: 5:20.10.0~3-0~raspbian-buster
 docker_version_armv7: 5:19.03.12~3-0~raspbian-buster
 docker_version_arm64: 5:19.03.9~3-0~debian-buster
 
 # Check available versions on a Pi: `apt-cache madison docker-ce`
-docker_version: "{{ docker_version_armv7 if 'armv7' in ansible_architecture else docker_version_arm64 }}"
+docker_version: "{{ docker_version_armv7 if 'armv7' in ansible_architecture else docker_version_armv6 if 'armv6' in ansible_architecture else docker_version_arm64 }}"
 
 # Whether to install recommended packages alongside docker-ce.
 docker_install_recommends: false


### PR DESCRIPTION
This change enables to install Docker on the Raspberry Pi Zero.

Note that the installation of Docker Compose does not work on the Zero with the current code.  I tried some but I have not found a simple way to install Compose.

Thanks!!